### PR TITLE
Move reference to `gatsby-source-filesystem` above `gatsby-plugin-mdx`

### DIFF
--- a/gatsby-theme-code-notes/gatsby-config.js
+++ b/gatsby-theme-code-notes/gatsby-config.js
@@ -44,6 +44,13 @@ module.exports = (options) => {
       'gatsby-plugin-typescript',
       `gatsby-plugin-sharp`,
       `gatsby-transformer-sharp`,
+      {
+        resolve: `gatsby-source-filesystem`,
+        options: {
+          path: options.contentPath || `content/notes`,
+          name: options.contentPath || `content/notes`,
+        },
+      },
       mdxOtherwiseConfigured && {
         resolve: `gatsby-plugin-mdx`,
         options: {
@@ -67,13 +74,6 @@ module.exports = (options) => {
             [remarkTruncateLinks, { style: 'smart' }],
             unwrapImages,
           ],
-        },
-      },
-      {
-        resolve: `gatsby-source-filesystem`,
-        options: {
-          path: options.contentPath || `content/notes`,
-          name: options.contentPath || `content/notes`,
         },
       },
       `gatsby-plugin-redirects`,


### PR DESCRIPTION
Turns out that if gatsby-plugin-mdx is activated before
gatsby-source-filesystem, the build will fail when trying to query
for 'fields' in Mdx.

I'm not quite sure why this doesn't reproduce on my local builds,
but it reproduces consistently on my CI builds.